### PR TITLE
fix some code, add examples of learning lexicon from a dataset

### DIFF
--- a/pyccg/lexicon.py
+++ b/pyccg/lexicon.py
@@ -583,6 +583,7 @@ def get_candidate_categories(lex, tokens, sentence, smooth=1e-3):
 
   category_prior = lex.observed_category_distribution(
       exclude_tokens=set(tokens), soft_propagate_roots=True)
+
   if smooth is not None:
     L.debug("Smoothing category prior with k = %g", smooth)
     for key in category_prior.keys():
@@ -732,6 +733,9 @@ def attempt_candidate_parse(lexicon, token, candidate_category,
     sentence: Sentence which we are attempting to parse.
   """
 
+  get_arity = (lexicon.ontology and lexicon.ontology.get_expr_arity) \
+          or get_semantic_arity
+
   # Prepare dummy variable which will be inserted into parse checks.
   sub_target = dummy_var or l.Variable("F000")
   sub_expr = l.FunctionVariableExpression(sub_target)
@@ -797,6 +801,10 @@ def predict_zero_shot(lex, tokens, candidate_syntaxes, sentence, ontology,
     category_parse_results: TODO
     dummy_var: TODO
   """
+
+  get_arity = (lex.ontology and lex.ontology.get_expr_arity) \
+          or get_semantic_arity
+
   # Prepare for syntactic bootstrap: pre-calculate distributions over semantic
   # form elements conditioned on syntactic category.
   lf_ngrams = lex.lf_ngrams_mixed(alpha=alpha, order=1,

--- a/pyccg/logic.py
+++ b/pyccg/logic.py
@@ -2520,7 +2520,7 @@ def compute_type_raised_semantics(semantics):
   return LambdaExpression(var, semantics)
 
 def compute_function_semantics(function, argument):
-  print(function, argument, type(function), type(argument))
+  # print(function, argument, type(function), type(argument))
   return ApplicationExpression(function, argument).simplify()
 
 def compute_composition_semantics(function, argument):

--- a/pyccg/perceptron.py
+++ b/pyccg/perceptron.py
@@ -89,7 +89,7 @@ def update_perceptron_distant(lexicon, sentence, model, answer,
     if not correct_results:
       raise ValueError("No parses derived have the correct answer.")
     elif not incorrect_results:
-      L.warning("No incorrect parses. Skipping update.")
+      L.info("No incorrect parses. Skipping update.")
       return weighted_results, 0.0
 
   # Sort results by descending parse score.

--- a/scripts/clevr/learner.py
+++ b/scripts/clevr/learner.py
@@ -6,6 +6,7 @@ from pyccg.chart import WeightedCCGChartParser, printCCGDerivation
 from pyccg.model import Model
 from pyccg.lexicon import Lexicon
 from pyccg.logic import TypeSystem, Ontology, Expression
+from pyccg.word_learner import WordLearner
 
 
 ########
@@ -58,7 +59,6 @@ lex = Lexicon.fromstring(r"""
 
   the => N/N {\x.unique(x)}
   ball => N {\x.has_shape(x,sphere)}
-  cubic => N/N {\x.has_shape(x,cube)}
 """, ontology, include_semantics=True)
 
 
@@ -73,16 +73,20 @@ scene = {
   ]
 }
 
+# from IPython import embed; embed()
+
 model = Model(scene, ontology)
 print("the ball")
 print(model.evaluate(Expression.fromstring(r"unique(\x.has_shape(x,sphere))")))
 
-
 ######
 # Parse an utterance and execute.
 
-parser = WeightedCCGChartParser(lex)
-results = parser.parse("the ball".split())
+learner = WordLearner(lex)
+learner.update_with_example("the cube".split(), model, scene['objects'][1])
+
+parser = WeightedCCGChartParser(learner.lexicon)
+results = parser.parse("the cube".split())
 printCCGDerivation(results[0])
 
 root_token, _ = results[0].label()

--- a/scripts/clevr/learner.py
+++ b/scripts/clevr/learner.py
@@ -73,8 +73,6 @@ scene = {
   ]
 }
 
-# from IPython import embed; embed()
-
 model = Model(scene, ontology)
 print("the ball")
 print(model.evaluate(Expression.fromstring(r"unique(\x.has_shape(x,sphere))")))

--- a/scripts/clevr/learner_dataset.py
+++ b/scripts/clevr/learner_dataset.py
@@ -1,0 +1,161 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File   : learner_dataset.py
+# Author : Jiayuan Mao
+# Email  : maojiayuan@gmail.com
+# Date   : 01/16/2019
+#
+# Distributed under terms of the MIT license.
+
+import random
+
+from pyccg.chart import WeightedCCGChartParser, printCCGDerivation
+from pyccg.model import Model
+from pyccg.lexicon import Lexicon
+from pyccg.logic import TypeSystem, Ontology, Expression
+from pyccg.word_learner import WordLearner
+
+
+########
+# Ontology: defines a type system, constants, and predicates available for use
+# in logical forms.
+
+
+class Object(object):
+  def __init__(self, shape, size, material):
+    self.shape = shape
+    self.size = size
+    self.material = material
+
+  def __hash__(self):
+    return hash((self.shape, self.size, self.material))
+
+  def __eq__(self, other):
+    return other.__class__ == self.__class__ and hash(self) == hash(other)
+
+  def __str__(self):
+    return "Object(%s, %s, %s)" % (self.shape, self.size, self.material)
+
+
+def fn_unique(xs):
+  true_xs = [x for x, matches in xs.items() if matches]
+  assert len(true_xs) == 1
+  return true_xs[0]
+
+
+def fn_exists(xs):
+  true_xs = [x for x, matches in xs.items() if matches]
+  return len(true_xs) > 0
+
+
+types = TypeSystem(["object", "boolean", "shape", "size"])
+
+functions = [
+  types.new_function("has_shape", ("object", "shape", "boolean"), lambda x, s: x.shape == s),
+  types.new_function("unique", (("object", "boolean"), "object"), fn_unique),
+  types.new_function("object_exists", (("object", "boolean"), "boolean"), fn_exists),
+]
+
+constants = [
+  types.new_constant("sphere", "shape"),
+  types.new_constant("cube", "shape"),
+  types.new_constant("cylinder", "shape"),
+]
+
+ontology = Ontology(types, functions, constants)
+
+
+#######
+# Lexicon: defines an initial set of word -> (syntax, meaning) mappings.
+# Weights are initialized uniformly by default.
+
+
+initial_lex = Lexicon.fromstring(r"""
+  :- S, N
+
+  any => S/N {\x.object_exists(x)}
+  _dummy_noun => N {\x. True}
+""", ontology, include_semantics=True)
+
+
+#######
+# VQA Dataset: defines the dataset.
+
+
+class VQADataset(object):
+    """
+    A dummy dataset contains tuples of (scene, question, answer).
+    Each scene contains only one objects with one of the three shapes ('sphere', 'cube' and 'cylinder').
+    There are three types of questions: "any sphere", "any cube", "any cylinder".
+    The answer is True if the shape of interest in the question match the shape of the visual object.
+    """
+    def __init__(self, dataset_size):
+        super().__init__()
+        self.dataset_size = dataset_size
+        self.data = list()
+        self._gen_data()
+
+    def _gen_data(self):
+        def gen_shape():
+            return random.choice(['sphere', 'cube', 'cylinder'])
+
+        for i in range(self.dataset_size):
+            scene = dict(objects=[
+                Object(gen_shape(), 'big', 'rubber')
+            ])
+
+            soi = gen_shape()  # shape-of-interest
+            question = 'any ' + soi
+            answer = scene['objects'][0].shape == soi
+
+            self.data.append((scene, question, answer))
+
+    def __getitem__(self, index):
+        return self.data[index]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]
+
+
+def learn_dataset(initial_lex, dataset_size):
+    """"Learn the lexicon from a randomly generated data."""
+    dataset = VQADataset(dataset_size)
+
+    def iter_data():
+        """Helper function for iterating dataset and inject the ontology to make the scene a model for execution."""
+        for v, q, a in dataset:
+            yield (Model(v, ontology), q.split(), a)
+
+    learner = WordLearner(initial_lex)
+    try:
+        for v, q, a in iter_data():
+            learner.update_with_example(q, v, a, verbose=False)
+    except Exception as e:
+        print(e)
+        raise e
+    finally:
+        del iter_data
+
+    return learner.lexicon
+
+
+lex = learn_dataset(initial_lex, 1000)
+
+print('Learned lexicon')
+print('-' * 120)
+lex.debug_print()
+print()
+
+print('Examplar parsing')
+print('-' * 120)
+parser = WeightedCCGChartParser(lex)
+results = parser.parse("any cube".split())
+printCCGDerivation(results[0])
+
+root_token, _ = results[0].label()
+print(root_token.semantics())
+

--- a/scripts/clevr/learner_dataset.py
+++ b/scripts/clevr/learner_dataset.py
@@ -145,12 +145,12 @@ def learn_dataset(initial_lex, dataset_size):
 
 lex = learn_dataset(initial_lex, 1000)
 
-print('Learned lexicon')
+print('Learned lexicon:')
 print('-' * 120)
 lex.debug_print()
 print()
 
-print('Examplar parsing')
+print('Example:')
 print('-' * 120)
 parser = WeightedCCGChartParser(lex)
 results = parser.parse("any cube".split())


### PR DESCRIPTION
This pull request contains the fix of the missing function `get_arity` and a new `verbose` argument for the function `update_with_example` to reduce the printed messages during running. It also contains a new learning example `scripts/clevr/learner_dataset.py`. I have also added a real "learning" procedure to `scripts/clevr/learner.py`.

Please kindly review these codes and correct me if I'm wrong... Thanks!